### PR TITLE
Add Dependabot configuration for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"


### PR DESCRIPTION
# Summary

Adds Dependabot integration to automatically monitor and update GitHub Actions dependencies.

## Changes

- Add `.github/dependabot.yml` configuration
- Monitors `github-actions` ecosystem for updates
- Runs weekly on Mondays
- Limits to 5 open PRs at a time
- Labels PRs with `dependencies` and `github-actions`