### PR TITLE
Update keystone-cli to version 0.2.0

### DIFF
--- a/Formula/keystone-cli.rb
+++ b/Formula/keystone-cli.rb
@@ -1,26 +1,26 @@
 class KeystoneCli < Formula
   desc "Command-line interface for Keystone"
   homepage "https://github.com/Knight-Owl-Dev/keystone-cli"
-  version "0.1.9"
+  version "0.2.0"
   license "MIT"
 
   on_macos do
     if Hardware::CPU.arm?
-      url "https://github.com/Knight-Owl-Dev/keystone-cli/releases/download/v0.1.9/keystone-cli_0.1.9_osx-arm64.tar.gz"
-      sha256 "5acb67f220135c72bd6347ae19e0dbf40c078c3821d2c0b638914e255d9210b7"
+      url "https://github.com/Knight-Owl-Dev/keystone-cli/releases/download/v0.2.0/keystone-cli_0.2.0_osx-arm64.tar.gz"
+      sha256 "153418d9a2874253e30055b7ceb1d09f7b2b9c66666ea21d204bdd9f28136ea8"
     else
-      url "https://github.com/Knight-Owl-Dev/keystone-cli/releases/download/v0.1.9/keystone-cli_0.1.9_osx-x64.tar.gz"
-      sha256 "4a9fc64d5e8a530b652656f0977749f67f2b0d5b0e84406f494694c4919bcd95"
+      url "https://github.com/Knight-Owl-Dev/keystone-cli/releases/download/v0.2.0/keystone-cli_0.2.0_osx-x64.tar.gz"
+      sha256 "39a586af391df07c804b32a889ce54a6f8d4df9a13b890e76ba959a278d3203b"
     end
   end
 
   on_linux do
     if Hardware::CPU.arm?
-      url "https://github.com/Knight-Owl-Dev/keystone-cli/releases/download/v0.1.9/keystone-cli_0.1.9_linux-arm64.tar.gz"
-      sha256 "a455bb4c1ade1f0e384c689fc22105ebeeb01448faa78b1fd3bf9400acec3b29"
+      url "https://github.com/Knight-Owl-Dev/keystone-cli/releases/download/v0.2.0/keystone-cli_0.2.0_linux-arm64.tar.gz"
+      sha256 "16ecedac8b3767664e6787bdc6dc3828f9e7f1a4a319a5caec5763a97d948c62"
     else
-      url "https://github.com/Knight-Owl-Dev/keystone-cli/releases/download/v0.1.9/keystone-cli_0.1.9_linux-x64.tar.gz"
-      sha256 "275f8d6c336da51e3e765d05343c8de7fcecfd8ceaae2f6a6fca4628d83376ab"
+      url "https://github.com/Knight-Owl-Dev/keystone-cli/releases/download/v0.2.0/keystone-cli_0.2.0_linux-x64.tar.gz"
+      sha256 "2dac50ad132f42503dff3ed98b79a5fabb13839a5be098e97f56604b3fc744ce"
     end
   end
 


### PR DESCRIPTION
## Summary
- Update keystone-cli formula from 0.1.9 to 0.2.0
- Update all platform URLs and SHA256 checksums

## Test plan
- [ ] CI passes `brew test-bot` on all platforms (Ubuntu, Intel Mac, ARM Mac)

🤖 Generated with [Claude Code](https://claude.ai/code)