### PR TITLE
Add actionlint to CI workflow

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,6 +7,18 @@ on:
   pull_request:
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup actionlint
+        uses: raven-actions/actionlint@v2
+
+      - name: Check GitHub Actions workflows (actionlint)
+        run: actionlint
+
   test-bot:
     strategy:
       matrix:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ brew style --fix scripts/
 
 ## CI/CD
 
-- **tests.yml**: Runs `brew test-bot` on PRs and pushes to main (Ubuntu, Intel Mac, ARM Mac)
+- **tests.yml**: Runs linting (actionlint) and `brew test-bot` on PRs and pushes to main
 - **update-formula.yml**: Updates formulas to latest versions, creates PR with auto-merge
   - Trigger manually via Actions tab, or via `repository_dispatch` from upstream repos
   - Requires `PR_TOKEN` secret (PAT with `repo` scope)


### PR DESCRIPTION
## Summary

Adds a dedicated lint job to the CI workflow that runs actionlint to validate GitHub Actions workflow files.

Closes #17

## Changes

- Add `lint` job to `tests.yml` that runs on `ubuntu-latest`
- Uses `raven-actions/actionlint@v2` to set up and run actionlint
- Update `CLAUDE.md` to document the new lint job