### PR TITLE
SHA-pin all GitHub Actions for supply-chain security

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     container: ghcr.io/knight-owl-dev/ci-tools:latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - run: make lint SKIP=lint-brew
 
   test-bot:
@@ -30,12 +30,12 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@98cfa07b984a61682e6cd3a0833fad2006cc84ba # main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Cache Homebrew Bundler RubyGems
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ matrix.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}
@@ -53,7 +53,7 @@ jobs:
 
       - name: Upload bottles as artifact
         if: always() && github.event_name == 'pull_request'
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: bottles_${{ matrix.os }}
           path: '*.bottle.*'

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -30,20 +30,20 @@ jobs:
         run: git config --global init.defaultBranch main
 
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 
       - name: Generate GitHub App token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
 
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@main
+        uses: Homebrew/actions/setup-homebrew@98cfa07b984a61682e6cd3a0833fad2006cc84ba # main
         with:
           token: ${{ steps.app-token.outputs.token }}
 

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ lint-brew: ## Check Ruby style (brew style)
 lint-action: ## Check GitHub Actions (actionlint)
 	actionlint .github/workflows/*.yml
 	@echo "OK"
+	validate-action-pins .github/workflows/*.yml
+	@echo "OK"
 
 lint-md: ## Check Markdown (markdownlint)
 	markdownlint-cli2 "**/*.md"


### PR DESCRIPTION
# Summary

Pin every `uses:` reference in the workflow files to a full commit SHA with a semver version comment, per the supply-chain policy used in the devops repo.

Closes #50.

## Changes

- `.github/workflows/ci.yml` — SHA-pin `actions/checkout` (v6.0.2),   `actions/cache` (v5.0.5), `actions/upload-artifact` (v7.0.1), and  `Homebrew/actions/setup-homebrew` (branch `main`).
- `.github/workflows/update-formula.yml` — SHA-pin `actions/checkout`  (v6.0.2), `actions/create-github-app-token` (v3.1.1), and `Homebrew/actions/setup-homebrew` (branch `main`).
- `Makefile` — run `validate-action-pins` as part of `make lint-action`,  so pin/comment consistency is enforced in CI and locally.

`Homebrew/actions/setup-homebrew` has no tagged releases upstream, so it is pinned to a specific commit on `main`. Dependabot can't auto-bump branch-SHA pins without tags, so this one needs periodic manual review — see knight-owl-dev/devops#122 for tooling to help with that.