### PR TITLE
Migrate create-github-app-token from app-id to client-id

### DIFF
--- a/.github/actionlint.yaml
+++ b/.github/actionlint.yaml
@@ -1,0 +1,4 @@
+# Allowed `vars.*` references in workflows. See:
+# https://github.com/rhysd/actionlint/blob/main/docs/config.md
+config-variables:
+  - APP_CLIENT_ID

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -38,7 +38,7 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
         with:
-          app-id: ${{ secrets.APP_ID }}
+          client-id: ${{ vars.APP_CLIENT_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
           repositories: ${{ github.event.repository.name }}
 

--- a/docs/how-to/sync-formula.md
+++ b/docs/how-to/sync-formula.md
@@ -129,15 +129,15 @@ release workflow:
 ```yaml
 - name: Generate GitHub App token
   id: app-token
-  uses: actions/create-github-app-token@v2
+  uses: actions/create-github-app-token@1b10c78c7865c340bc4f6099eb2f838309f1e8c3 # v3.1.1
   with:
-    app-id: ${{ secrets.APP_ID }}
+    client-id: ${{ vars.APP_CLIENT_ID }}
     private-key: ${{ secrets.APP_PRIVATE_KEY }}
     owner: knight-owl-dev
     repositories: homebrew-tap
 
 - name: Trigger Homebrew tap update
-  uses: peter-evans/repository-dispatch@v4
+  uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
   with:
     token: ${{ steps.app-token.outputs.token }}
     repository: knight-owl-dev/homebrew-tap
@@ -145,10 +145,14 @@ release workflow:
     client-payload: '{"formulas": "my-formula:${{ needs.release.outputs.version }}"}'
 ```
 
+> SHAs shown here were current at the time of writing. When copying into your
+> own workflow, pin to the latest tagged release and keep the semver comment
+> — see [security.md](security.md#action-version-pinning).
+
 Required setup:
 
 1. Install the knight-owl-dev GitHub App on your package's repo
-2. Ensure `APP_ID` and `APP_PRIVATE_KEY` org secrets are available to your repo
+2. Ensure the `APP_CLIENT_ID` variable and `APP_PRIVATE_KEY` secret are available to your repo (org-level is fine)
 
 You can also trigger manually via the `gh` CLI:
 


### PR DESCRIPTION
# Summary

Switch `actions/create-github-app-token` from the deprecated `app-id` input to the new `client-id` input introduced in v3.1.0, using the `APP_CLIENT_ID` repo variable. Closes #54.

Closes #54 

## Changes

- `.github/workflows/update-formula.yml` — replace  `app-id: ${{ secrets.APP_ID }}` with  `client-id: ${{ vars.APP_CLIENT_ID }}`. Silences the  `Input 'app-id' has been deprecated` warning.
- `docs/how-to/sync-formula.md` — update the release-workflow example to match: `client-id` input, version bumped from v2 to v3.1.1 (since `client-id` only exists from v3.1.0 onward), and SHA-pin both example actions with semver comments so downstream consumers copy-paste a compliant pattern. Added a short note linking to `security.md` for the pinning policy.
- Setup instructions updated: `APP_CLIENT_ID` variable + `APP_PRIVATE_KEY`  secret instead of two secrets.

## Follow-up

The `APP_ID` secret is now unused and can be deleted from repo/org settings
once this merges and the workflow runs green on a dispatch.