### PR TITLE
Add action-pin-monitor workflow for branch-pinned actions

### DIFF
--- a/.github/workflows/action-pin-monitor.yml
+++ b/.github/workflows/action-pin-monitor.yml
@@ -1,0 +1,105 @@
+name: Action Pin Monitor
+
+# Dependabot does not refresh SHA pins that track a branch (e.g. @<sha> # main).
+# This workflow scans our branch pins weekly and opens a deduped GitHub issue
+# when any pin has drifted behind its upstream branch head. See issue #58.
+
+on:
+  schedule:
+    # Monday at 08:00 UTC
+    - cron: '0 8 * * 1'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: action-pin-monitor
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      issues: write
+
+    steps:
+      - name: Checkout
+        # Sparse checkout: workflow files to scan, the issue body template,
+        # and the install script.
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout: |
+            .github/workflows
+            docs/action-pin-issue.md
+            scripts/install-ci-tools.sh
+          sparse-checkout-cone-mode: false
+          persist-credentials: false
+
+      - name: Install ci-tools
+        run: |
+          ./scripts/install-ci-tools.sh
+          validate-action-pins --version
+
+      - name: Scan branch-pinned actions for drift
+        id: scan
+        env:
+          # Auth lifts validate-action-pins from 60 req/hr (unauth) to 5000 req/hr.
+          GITHUB_TOKEN: ${{ github.token }}
+        run: |
+          # TSV columns: file, action, ref, head-sha, kind.
+          # head-sha is empty when up-to-date, short SHA when behind the branch head.
+          stale=$(
+            validate-action-pins updates --format=tsv --only branch \
+              .github/workflows/*.yml \
+              | awk -F'\t' 'NF == 5 && $5 == "branch" && $4 != ""'
+          )
+          if [ -z "${stale}" ]
+          then
+            echo "No stale branch pins."
+            exit 0
+          fi
+          echo "Stale pins detected:"
+          echo "${stale}"
+          {
+            echo "stale<<STALE_EOF"
+            echo "${stale}"
+            echo "STALE_EOF"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Open issue on drift
+        if: steps.scan.outputs.stale != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          STALE: ${{ steps.scan.outputs.stale }}
+        run: |
+          open_issues=$(
+            gh issue list \
+              --label action-pin-update \
+              --state open \
+              --limit 1 \
+              --json number \
+              --jq 'length'
+          )
+          if [ "${open_issues}" -gt 0 ]; then
+            echo "Open action-pin-update issue already exists — skipping."
+            exit 0
+          fi
+
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+
+          pins_md=$(
+            printf '%s\n' "${STALE}" | awk -F'\t' '{
+              printf "- `%s`: `%s` on `%s` — behind branch head `%s`\n", $1, $2, $3, $4
+            }'
+          )
+
+          awk -v pins="${pins_md}" -v url="${run_url}" '
+            { gsub(/\$STALE_PINS/, pins); gsub(/\$RUN_URL/, url); print }
+          ' docs/action-pin-issue.md > /tmp/issue-body.md
+
+          gh issue create \
+            --title "Action Pin Monitor: stale branch pins detected" \
+            --body-file /tmp/issue-body.md \
+            --label action-pin-update

--- a/docs/action-pin-issue.md
+++ b/docs/action-pin-issue.md
@@ -18,6 +18,6 @@ $STALE_PINS
 3. Update the `uses:` line in the affected workflow file; keep the
    `# <branch>` comment intact.
 4. Open a PR. CI's `make lint-action` validates the new pin via
-   `validate-action-pins check`.
+   `validate-action-pins`.
 
 See [docs/how-to/security.md](docs/how-to/security.md) for the pinning policy.

--- a/docs/action-pin-issue.md
+++ b/docs/action-pin-issue.md
@@ -1,0 +1,23 @@
+<!-- markdownlint-disable MD041 — no h1 needed; GitHub injects the issue title -->
+
+## Action Pin Monitor Alert
+
+The scheduled pin check found branch-pinned GitHub Actions whose SHA is behind
+the upstream branch head. Dependabot doesn't bump branch-SHA pins, so these
+need a manual refresh.
+
+### Stale Pins
+
+$STALE_PINS
+
+### Next Steps
+
+1. Review the [workflow run]($RUN_URL) that produced this report.
+2. For each stale pin, resolve the latest upstream SHA —
+   `gh api /repos/<owner>/<repo>/commits/<branch> --jq .sha`.
+3. Update the `uses:` line in the affected workflow file; keep the
+   `# <branch>` comment intact.
+4. Open a PR. CI's `make lint-action` validates the new pin via
+   `validate-action-pins check`.
+
+See [docs/how-to/security.md](docs/how-to/security.md) for the pinning policy.

--- a/docs/how-to/security.md
+++ b/docs/how-to/security.md
@@ -125,12 +125,15 @@ version and propose clean minor/patch bumps.
 **Branch-pinned actions**: A few upstream actions publish no tagged releases
 (e.g., `Homebrew/actions/setup-homebrew`). Pin these to a specific commit on
 the default branch. Dependabot cannot auto-bump branch-SHA pins without tags,
-so these require periodic manual review.
+so the [`action-pin-monitor`](../../.github/workflows/action-pin-monitor.yml)
+workflow runs weekly and files a deduped issue when any such pin drifts
+behind its upstream branch head.
 
 **Enforcement**: `make lint-action` runs `validate-action-pins` (shipped in
-the `ci-tools` image), which resolves each pinned SHA against its claimed tag
-via the GitHub API and fails the lint if they do not match. Branch-pinned
-actions emit a warning (tag cannot be resolved) but do not fail.
+the `ci-tools` image), which resolves each pinned SHA against its claimed ref
+via the GitHub API. Tag pins fail the lint on mismatch; branch pins emit a
+warning noting how many commits they trail the branch head by (branch heads
+move, so a lagging pin is informational, not a hard failure).
 
 ### Checkout Security
 

--- a/scripts/install-ci-tools.sh
+++ b/scripts/install-ci-tools.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install the ci-tools apt package from https://apt.knight-owl.dev.
+#
+# Usage:
+#   ./scripts/install-ci-tools.sh
+#
+# Verifies the repository's GPG key against the fingerprint published in
+# knight-owl-dev/apt so a CDN compromise can't silently swap keys.
+# Intended for Debian/Ubuntu CI runners; requires sudo and curl.
+
+# Fingerprint published in https://github.com/knight-owl-dev/apt/blob/main/README.md
+EXPECTED_FPR="25F3E04AE420DC2A0F181ADC89B3FD22D2085FDA"
+KEYRING="/usr/share/keyrings/knight-owl.gpg"
+SOURCES_LIST="/etc/apt/sources.list.d/knight-owl.list"
+
+curl -fsSL https://apt.knight-owl.dev/PUBLIC.KEY |
+  sudo gpg --dearmor -o "${KEYRING}"
+
+actual_fpr=$(
+  gpg --show-keys --with-colons "${KEYRING}" |
+    awk -F: '$1 == "fpr" {print $10; exit}'
+)
+if [[ "${actual_fpr}" != "${EXPECTED_FPR}" ]]
+then
+  echo "GPG key fingerprint mismatch:" >&2
+  echo "  expected: ${EXPECTED_FPR}" >&2
+  echo "  actual:   ${actual_fpr}" >&2
+  exit 1
+fi
+
+echo "deb [signed-by=${KEYRING}] https://apt.knight-owl.dev stable main" |
+  sudo tee "${SOURCES_LIST}" >/dev/null
+
+sudo apt-get update
+sudo apt-get install -y ci-tools


### PR DESCRIPTION
# Summary

Adds a weekly scheduled workflow that detects drift in branch-pinned GitHub Actions (e.g. `Homebrew/actions/setup-homebrew@<sha> # main`) and files a deduped issue when any pin has fallen behind.

Implements Option A from #58.

## Changes

- `.github/workflows/action-pin-monitor.yml` — weekly (+ `workflow_dispatch`) scan, runs on `ubuntu-latest`, uses `gh` for label + issue management. Dedups via the pre-created `action-pin-update` label.
- `scripts/install-ci-tools.sh` — installs `ci-tools` from `apt.knight-owl.dev` after verifying the signing key fingerprint against the one published in `knight-owl-dev/apt`.
- `docs/action-pin-issue.md` — issue body template rendered at run time (mirrors `docs/cve-monitor-issue.md` in devops).
- `docs/how-to/security.md` — updated the branch-pin section: the `validate-action-pins` WARN now reports drift distance (not tag-resolution failure), and the periodic review is no longer manual.

Label `action-pin-update` was created manually on the repo as a one-time setup.

Closes #58.