### PR TITLE
Refresh Homebrew/actions/setup-homebrew branch pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@98cfa07b984a61682e6cd3a0833fad2006cc84ba # main
+        uses: Homebrew/actions/setup-homebrew@6eaeff80e7e5c43087c0e5eb5aa82120399e9c91 # main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -43,7 +43,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
 
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@98cfa07b984a61682e6cd3a0833fad2006cc84ba # main
+        uses: Homebrew/actions/setup-homebrew@6eaeff80e7e5c43087c0e5eb5aa82120399e9c91 # main
         with:
           token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
Closes #61

## Summary

- Bump the SHA pin for `Homebrew/actions/setup-homebrew@main` from `98cfa07b` to `6eaeff80` in `ci.yml` and `update-formula.yml`.
- Dependabot does not refresh branch-SHA pins; `action-pin-monitor` flagged the drift in #61.
- Verified locally with `validate-action-pins` — all pins resolve OK.

## Test plan

- [ ] CI's `make lint-action` validates the new pin via `validate-action-pins`.
- [ ] `brew test-bot` job runs against the refreshed setup-homebrew action.

🤖 Generated with [Claude Code](https://claude.com/claude-code)