### PR TITLE
Keep test-bot working under Homebrew's new tap-trust check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,6 +29,11 @@ jobs:
       # so rootless Bubblewrap can't start the Linux sandbox. This tap only
       # downloads pre-built binaries — no compilation happens to sandbox.
       HOMEBREW_NO_SANDBOX_LINUX: 1
+      # Homebrew's new tap-trust check fails `brew doctor` (run by
+      # test-bot --only-setup) on this local self-tap. Keep the pre-trust
+      # behavior during the transition (becomes the default in Homebrew
+      # 5.2/6.0); the tap under test is our own.
+      HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
     steps:
       - name: Configure git defaults
         run: git config --global init.defaultBranch main


### PR DESCRIPTION
## Summary

Homebrew shipped a new **tap-trust** check, and it makes `brew doctor` — run as part of `brew test-bot --only-setup` — fail on our local self-tap (`knight-owl-dev/tap` "not trusted"). That fails the `test-bot` job in CI **before any formula is even tested**, so every formula-update PR's CI breaks (e.g. the auto-generated "Update ci-tools to 1.2.7" PR #69). It's purely an upstream Homebrew behavior change, unrelated to the formula content.

## Changes

- Set `HOMEBREW_NO_REQUIRE_TAP_TRUST: 1` in the `test-bot` job env, keeping the pre-trust behavior during the transition (Homebrew makes trust the default in 5.2/6.0). Same class of CI-environment override as the existing `HOMEBREW_NO_SANDBOX_LINUX`.

## Further Comments

- The tap under test *is* our own repo, so the trust check adds no security value here.
- Longer-term alternative is to adopt trust explicitly (`HOMEBREW_REQUIRE_TAP_TRUST=1` + `brew trust knight-owl-dev/tap`); the transition flag is the lighter fit for a self-tap.
- Unblocks #69 once merged (re-run its CI).