### PR TITLE
Refresh Homebrew/actions/setup-homebrew branch pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,7 +40,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@6eaeff80e7e5c43087c0e5eb5aa82120399e9c91 # main
+        uses: Homebrew/actions/setup-homebrew@2ebcf16054461267868620b1414507f3ccc765c1 # main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -43,7 +43,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
 
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@6eaeff80e7e5c43087c0e5eb5aa82120399e9c91 # main
+        uses: Homebrew/actions/setup-homebrew@2ebcf16054461267868620b1414507f3ccc765c1 # main
         with:
           token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
Closes #68

The scheduled action-pin monitor flagged the `Homebrew/actions/setup-homebrew` branch-SHA pin as behind the upstream `main` head (Dependabot doesn't bump branch-SHA pins, so it needs a manual refresh).

Bumps the pin in both `ci.yml` and `update-formula.yml` from `6eaeff80` to the current `main` head `2ebcf16`. The `# main` comment is preserved, and `validate-action-pins` (run by `make lint-action` in CI) confirms the new SHA still resolves to the branch head.