### PR TITLE
Drop HOMEBREW_NO_REQUIRE_TAP_TRUST workaround

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,11 +29,6 @@ jobs:
       # so rootless Bubblewrap can't start the Linux sandbox. This tap only
       # downloads pre-built binaries — no compilation happens to sandbox.
       HOMEBREW_NO_SANDBOX_LINUX: 1
-      # Homebrew's new tap-trust check fails `brew doctor` (run by
-      # test-bot --only-setup) on this local self-tap. Keep the pre-trust
-      # behavior during the transition (becomes the default in Homebrew
-      # 5.2/6.0); the tap under test is our own.
-      HOMEBREW_NO_REQUIRE_TAP_TRUST: 1
     steps:
       - name: Configure git defaults
         run: git config --global init.defaultBranch main


### PR DESCRIPTION
Closes #75

`Homebrew/actions/setup-homebrew` now runs `brew trust "$HOMEBREW_TAP_NAME"` during setup for non-`homebrew/*` taps (upstream [PR #860](https://github.com/Homebrew/actions/pull/860) / [#861](https://github.com/Homebrew/actions/pull/861), pinned into this repo in #74). That trusts `knight-owl-dev/tap` for us — the official fix for [Homebrew/brew#22494](https://github.com/Homebrew/brew/issues/22494), the same tap-trust check `HOMEBREW_NO_REQUIRE_TAP_TRUST=1` was working around.

This drops the now-redundant env var from `ci.yml`. The two were stacked solutions to the same problem.

## Verification

This is the empirical test called for in #75 — the proof is this PR's CI run, since `brew test-bot --only-setup` (which runs `brew doctor`) executes on every event, and `--only-formulae` runs on the pull_request event. If the full matrix passes without the env var, the workaround is confirmed redundant. If `doctor` fails, the env var is still needed and should be restored with a comment documenting why.

## Checklist

- [ ] test-bot green on `ubuntu-24.04`, `macos-15-intel`, `macos-26`