### PR TITLE
Refresh Homebrew/actions/setup-homebrew branch pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@2ebcf16054461267868620b1414507f3ccc765c1 # main
+        uses: Homebrew/actions/setup-homebrew@6315ef70a8bfcd2c71104383846591ac113ace33 # main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -43,7 +43,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
 
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@2ebcf16054461267868620b1414507f3ccc765c1 # main
+        uses: Homebrew/actions/setup-homebrew@6315ef70a8bfcd2c71104383846591ac113ace33 # main
         with:
           token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
# Summary

Refreshes the stale `Homebrew/actions/setup-homebrew` pin (tracking `main`) in `ci.yml` and `update-formula.yml`, from `2ebcf160` to `6315ef70`. Closes #78.

## Changes

Dependabot doesn't bump branch-SHA pins, so the scheduled action-pin monitor (#78) flagged these as behind the upstream branch head.

Reviewed the upstream diff before bumping: `main` is 15 commits ahead, 0 behind. The only consumer-facing interface change is a new optional `setup-sandbox` input that defaults to `false`, so our callers are unaffected. The remainder is the gated implementation plus routine dependabot/test commits.

`make lint-action` passes — `validate-action-pins` confirms both pins resolve to `main`.