### PR TITLE
Refresh Homebrew/actions/setup-homebrew branch pin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Set up Homebrew
         id: set-up-homebrew
-        uses: Homebrew/actions/setup-homebrew@6315ef70a8bfcd2c71104383846591ac113ace33 # main
+        uses: Homebrew/actions/setup-homebrew@841d750a0ed9262d3c3ca31f2173974696bc261a # main
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/update-formula.yml
+++ b/.github/workflows/update-formula.yml
@@ -43,7 +43,7 @@ jobs:
           repositories: ${{ github.event.repository.name }}
 
       - name: Set up Homebrew
-        uses: Homebrew/actions/setup-homebrew@6315ef70a8bfcd2c71104383846591ac113ace33 # main
+        uses: Homebrew/actions/setup-homebrew@841d750a0ed9262d3c3ca31f2173974696bc261a # main
         with:
           token: ${{ steps.app-token.outputs.token }}
 


### PR DESCRIPTION
Refreshes the stale `Homebrew/actions/setup-homebrew` `main`-branch pin in `ci.yml` and `update-formula.yml` from `6315ef70` to `841d750a`, the current branch head.

Upstream is 6 commits ahead, 0 behind. None touch `setup-homebrew/` — the deltas delete the `create-gcloud-instance` action and bump Homebrew's own npm/checkout deps, so our callers are unaffected.

`make lint-action` passes; `validate-action-pins` confirms the new SHA resolves to `main`.

Closes #83