### PR TITLE
Drop redundant formula version, update ci-tools to 1.4.0

### DIFF
--- a/Formula/ci-tools.rb
+++ b/Formula/ci-tools.rb
@@ -5,7 +5,6 @@ class CiTools < Formula
 
   desc "CI/CD tools for GitHub Actions workflows"
   homepage "https://github.com/#{REPO}"
-  version VERSION
   license "MIT"
 
   depends_on "curl"

--- a/Formula/keystone-cli.rb
+++ b/Formula/keystone-cli.rb
@@ -5,7 +5,6 @@ class KeystoneCli < Formula
 
   desc "Command-line interface for Keystone"
   homepage "https://github.com/#{REPO}"
-  version VERSION
   license "MIT"
 
   on_macos do

--- a/Manifests/ci-tools.rb
+++ b/Manifests/ci-tools.rb
@@ -5,15 +5,15 @@
 # Update with: scripts/update-formula.sh ci-tools <version>
 
 module CiToolsManifest
-  VERSION = "1.3.6"
+  VERSION = "1.4.0"
   REPO = "knight-owl-dev/devops"
   TAG_PREFIX = "v"
   ASSET_TEMPLATE = "ci-tools_%<version>s_%<platform>s.tar.gz"
 
   SHA256 = {
-    "osx-arm64"   => "456e7eca3b941f3dd7ad9479afc2d1c6e872cc258707ee3527cda11084c43ce6",
-    "osx-x64"     => "456e7eca3b941f3dd7ad9479afc2d1c6e872cc258707ee3527cda11084c43ce6",
-    "linux-arm64" => "456e7eca3b941f3dd7ad9479afc2d1c6e872cc258707ee3527cda11084c43ce6",
-    "linux-x64"   => "456e7eca3b941f3dd7ad9479afc2d1c6e872cc258707ee3527cda11084c43ce6",
+    "osx-arm64"   => "0d859ea3a075e9df6c19a7ca628c0237fe9d2895f73aca7ec9586f6cf422cb24",
+    "osx-x64"     => "0d859ea3a075e9df6c19a7ca628c0237fe9d2895f73aca7ec9586f6cf422cb24",
+    "linux-arm64" => "0d859ea3a075e9df6c19a7ca628c0237fe9d2895f73aca7ec9586f6cf422cb24",
+    "linux-x64"   => "0d859ea3a075e9df6c19a7ca628c0237fe9d2895f73aca7ec9586f6cf422cb24",
   }.freeze
 end

--- a/docs/how-to/add-formula/README.md
+++ b/docs/how-to/add-formula/README.md
@@ -17,7 +17,8 @@ Create `Manifests/<formula-name>.rb` using the
 **Notes:**
 
 - Module name must be PascalCase version of the formula name plus `Manifest` (e.g., `KeystoneCliManifest`)
-- `TAG_PREFIX` is typically `"v"` for tags like `v1.0.0`, or `""` for tags like `1.0.0`
+- `TAG_PREFIX` must be `"v"` for tags like `v1.0.0`, or `""` for tags like `1.0.0`. Homebrew scans
+  the version from the release tag in the download URL, and only these two forms are recognized
 - `ASSET_TEMPLATE` uses Ruby `format()` syntax with `%<version>s` and `%<platform>s` placeholders
 
 ## Step 2: Create the Formula

--- a/docs/how-to/add-formula/formula-template.rb.md
+++ b/docs/how-to/add-formula/formula-template.rb.md
@@ -15,7 +15,6 @@ class Example < Formula
 
   desc "<description>"
   homepage "https://github.com/#{REPO}"
-  version VERSION
   license "<license>"
 
   on_macos do


### PR DESCRIPTION
# Summary

Fixes the `brew test-bot --only-tap-syntax` failure blocking CI and the update-formula
workflow, and lands the ci-tools 1.4.0 update that failure held back.

## Changes

Homebrew 6.0.14 added a URL parser that scans the version from the release tag in GitHub
download URLs (Homebrew/brew@bae7b0408a). With that, the explicit `version VERSION` in each
formula duplicates what Homebrew infers, so `brew audit` reports:

    Stable: `version 0.2.2` is redundant with version scanned from URL

- Removed `version VERSION` from `Formula/ci-tools.rb`, `Formula/keystone-cli.rb`, and the
  formula template. `Manifests/` stays the source of truth: `VERSION` still builds the URLs,
  and Homebrew reads the version back from the tag segment.
- Documented that this constrains `TAG_PREFIX` to `""` or `"v"`, the two forms the URL scanner
  recognizes. A tag like `ci-tools-v1.4.0` detects as `64`.
- Updated ci-tools to 1.4.0 (separate commit). The `Update Formula` run on 2026-08-02 failed
  this audit before it could open a PR, and its `repository_dispatch` trigger won't retry.

Verified locally: `brew readall --os=all --arch=all` and `brew audit --except=installed
--tap=knight-owl-dev/tap` both pass, `brew install --build-from-source` + `brew test` pass for
both formulae, and `make lint` is clean.